### PR TITLE
[GITHUB-4] Add option to specify tar exclude and include

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 
 aws_bootstrap:
   teleport_mode: none
+  teleport_include: ansible Makefile
+  teleport_exclude: ".git:.venv:self.tgz"
   version: "1.4-22"
 
   ##

--- a/tasks/teleport_standard.yml
+++ b/tasks/teleport_standard.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: Prepare for teleportation
-  shell: "tar --exclude .git:.vagrant:self.tgz -czf self.tgz $(ls -d ansible Makefile 2>/dev/null)"
+  shell: "tar --exclude {{ aws_bootstrap.teleport_exclude }}
+    -czf self.tgz
+    $(ls -d {{ aws_bootstrap.teleport_include }} 2>/dev/null)"
   args:
     chdir: "{{ root_dir }}/.."
     creates: "{{ root_dir }}/../self.tgz"


### PR DESCRIPTION
You can now specify which files to teleport to your instance.
```YAML
aws_bootstrap:
  teleport_include: ansible Makefile requirements.txt
  teleport_exclude: ".git:.venv:self.tgz:.auto-generated-file"
```