### PR TITLE
[GITHUB-6] Switch from easy_install to setup.py

### DIFF
--- a/files/bootstrap.inc.sh
+++ b/files/bootstrap.inc.sh
@@ -25,8 +25,6 @@ function signal {
 }
 
 function cleanup {
-	chmod 777 /tmp/ansible.log
-
 	if [ "${DO_CLEANUP}" -ne 0 ]; then
 		rm -rf "${BOOTSTRAP_DIR}/environment.yml"
 	else

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -33,9 +33,10 @@
 
 - name: Install AWS cfn-bootstrap
   become: yes
-  command: "easy_install /usr/local/src/aws-cfn-bootstrap-{{ aws_bootstrap.version | regex_replace('^(.*?)-[0-9]+$', '\\1') }}"
+  command: "/usr/bin/env python setup.py install"
   args:
     creates: /usr/local/bin/cfn-init
+    chdir: "/usr/local/src/aws-cfn-bootstrap-{{ aws_bootstrap.version | regex_replace('^(.*?)-[0-9]+$', '\\1') }}"
 
 - name: Prepare landing folder
   become: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,7 +10,8 @@
     - role: ansible-city.aws_bootstrap
 
   post_tasks:
-    - name:
+    - name: Test cfn-init
+      become: yes
       command: /usr/local/bin/cfn-init --help
       register: cfninit_version
       tags:


### PR DESCRIPTION
The easy_install is no longer available in Ubuntu Bionic.